### PR TITLE
Fix title typo in index page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@300;400;600;700&family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
     <!-- Font Family Link End -->
-    <title> logoipsum'</title>
+    <title>Logo Ipsum</title>
   </head>
   <body>
     <!-- <noscript>You need to enable JavaScript to run this app.</noscript> -->


### PR DESCRIPTION
## Summary
- update title tag in `public/index.html`

## Testing
- `npx prettier -w public/index.html` *(fails: Unknown env config "http-proxy")*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a8fe3176c8320ad0515a0b3255665